### PR TITLE
remove non default features from esp-idf-svc

### DIFF
--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -24,7 +24,24 @@ experimental = ["esp-idf-svc/experimental"]
 
 [dependencies]
 log = "0.4"
-esp-idf-svc = { version = "0.51", features = ["critical-section", "embassy-time-driver", "embassy-sync"] }
+esp-idf-svc = "0.51"
+
+# --- Optional Embassy Integration ---
+# esp-idf-svc = { version = "0.51", features = ["critical-section", "embassy-time-driver", "embassy-sync"] }
+
+# If you enable embassy-time-driver, you MUST also add one of:
+
+# a) Standalone Embassy libs ( embassy-time, embassy-sync etc) with a foreign async runtime:
+# embassy-time = { version = "0.4.0", features = ["generic-queue-8"] } # NOTE: any generic-queue variant will work
+
+# b) With embassy-executor:
+# embassy-executor = { version = "0.7", features = ["executor-thread", "arch-std"] }
+
+# NOTE: if you use embassy-time with embassy-executor you don't need the generic-queue-8 feature
+
+# --- Temporary workaround for embassy-executor < 0.8 ---
+# esp-idf-svc = { version = "0.51", features = ["embassy-time-driver", "embassy-sync"] }
+# critical-section = { version = "1.1", features = ["std"], default-features = false }
 
 [build-dependencies]
 embuild = "0.33"


### PR DESCRIPTION

### Pull Request Details 📖
Disable features of esp-idf-svc that are non default.

#### Description
Since embassy-executor is pulled in indirectly via the embassy-time-queue-utils dependency in esp-idf-svc, a user must provide the correct feature set when the embassy-time-driver feature of esp-idf-svc is used. A failure to do so will fail to link properly. 

By default now exclude the feature, and add a section how a user might add in back correctly.
